### PR TITLE
fix: Update esbuild to >=0.25.0 to resolve CORS vulnerability

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,5 +33,8 @@
     "tailwindcss": "^3.3.5",
     "typescript": "^5.2.2",
     "vite": "^7.2.7"
+  },
+  "overrides": {
+    "esbuild": "^0.25.0"
   }
 }


### PR DESCRIPTION
Security fix for esbuild CORS vulnerability (MEDIUM severity).

- Added package override to force esbuild >=0.25.0
- Updated from 0.21.5 to 0.25.12
- npm audit shows 0 vulnerabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins esbuild to >=0.25.0 via package.json overrides to patch the known CORS vulnerability. Secures the frontend build tooling; npm audit now reports 0 vulnerabilities.

<sup>Written for commit 494458f1213c546aff2fe9560d0a4abc44ad2ece. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ensure stable esbuild version during dependency resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->