### PR TITLE
fix(security): Update python-multipart to fix arbitrary file write

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,7 +1,7 @@
 # FastAPI
 fastapi==0.123.0
 uvicorn[standard]==0.38.0
-python-multipart==0.0.20
+python-multipart>=0.0.22  # Updated to fix CVE-2024-47874 arbitrary file write
 starlette==0.50.0
 
 # Database


### PR DESCRIPTION
## Summary
- Update python-multipart>=0.0.22 to fix CVE-2024-47874
- Fixes arbitrary file write vulnerability via non-default configuration

## Test plan
- [ ] Verify pip install completes without errors
- [ ] Verify file upload functionality works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade python-multipart to >=0.0.22 to patch CVE-2024-47874 and prevent arbitrary file writes in non-default configurations. No app code changes; upload flows should continue to work.

- **Dependencies**
  - Set python-multipart to >=0.0.22 (was 0.0.20) to include the security fix and allow future patch updates.

- **Migration**
  - Run pip install to update the environment, then verify file uploads behave as expected.

<sup>Written for commit 6a623bbd0716811bda23395525fb727d51898265. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

