### PR TITLE
Remove cloud LLM refs — all inference is local

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A full-stack application for tracking maintenance, managing service reminders, a
 | Database | PostgreSQL 15+ with pgvector |
 | Vector DB | Qdrant (optional, for high-performance search) |
 | Cache | Redis (LLM responses, search results, embeddings, sessions, rate limiting) |
-| AI | Claude AI (Anthropic) or Docker Model Runner (local), Local Embeddings (sentence-transformers) |
+| AI | Anthropic API or Docker Model Runner (local), Local Embeddings (sentence-transformers) |
 | Observability | Redis Insight (GUI dashboard) |
 
 ---
@@ -256,7 +256,7 @@ DriveIQ/
 
 ### Search & AI
 - `POST /api/search` - Semantic search in documents
-- `POST /api/search/ask` - AI-powered Q&A with Claude
+- `POST /api/search/ask` - AI-powered Q&A with RAG
 
 ### Uploads
 - `GET /api/uploads` - List uploaded documents
@@ -303,7 +303,7 @@ LIMIT 5;
 - No API key required for embeddings
 
 ### LLM Inference
-- **Cloud**: Claude Sonnet (`claude-sonnet-4-20250514`) via Anthropic API
+- **Cloud**: Anthropic API (e.g., `claude-sonnet-4-20250514`)
 - **Local**: Docker Model Runner with OpenAI-compatible API (e.g., `ai/qwen3-coder`, `ai/glm-4.7-flash`, `ai/devstral-small-2`)
 - Unified `llm_client.py` abstraction with automatic Redis response caching
 - Set `USE_LOCAL_LLM=true` to switch to local inference
@@ -412,4 +412,4 @@ MIT License - see [LICENSE](LICENSE) for details
 
 ---
 
-Built with [Claude Code](https://github.com/anthropics/claude-code), [Commit-Relay](https://github.com/ry-ops/commit-relay), and [Git-Steer](https://github.com/ry-ops/git-steer) by Ry-Ops
+Built with [Commit-Relay](https://github.com/ry-ops/commit-relay) and [Git-Steer](https://github.com/ry-ops/git-steer) by Ry-Ops

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A full-stack application for tracking maintenance, managing service reminders, a
 | Database | PostgreSQL 15+ with pgvector |
 | Vector DB | Qdrant (optional, for high-performance search) |
 | Cache | Redis (LLM responses, search results, embeddings, sessions, rate limiting) |
-| AI | Anthropic API or Docker Model Runner (local), Local Embeddings (sentence-transformers) |
+| AI | Docker Model Runner (local LLM), Local Embeddings (sentence-transformers) |
 | Observability | Redis Insight (GUI dashboard) |
 
 ---
@@ -104,7 +104,7 @@ ALGORITHM=HS256
 ACCESS_TOKEN_EXPIRE_MINUTES=30
 
 # AI APIs
-ANTHROPIC_API_KEY=your-anthropic-api-key
+# ANTHROPIC_API_KEY=your-anthropic-api-key  # Not needed for local LLM
 
 # Vector Database (optional)
 QDRANT_HOST=localhost
@@ -114,9 +114,9 @@ QDRANT_COLLECTION=driveiq_docs
 # Redis
 REDIS_URL=redis://localhost:6379
 
-# Local LLM (optional, use instead of Anthropic API)
-USE_LOCAL_LLM=false
-ANTHROPIC_BASE_URL=
+# Local LLM
+USE_LOCAL_LLM=true
+ANTHROPIC_BASE_URL=http://model-runner.docker.internal:12434
 LOCAL_LLM_MODEL=ai/qwen3-coder
 
 # Vehicle Info
@@ -179,7 +179,7 @@ DriveIQ/
 │   │   │   ├── moe.py
 │   │   │   └── import_data.py
 │   │   ├── core/           # Config, database, security
-│   │   │   ├── llm_client.py     # LLM abstraction (cloud/local)
+│   │   │   ├── llm_client.py     # LLM abstraction (local inference)
 │   │   │   ├── qdrant_client.py  # Qdrant integration
 │   │   │   └── redis_client.py   # Caching, sessions, rate limiting
 │   │   ├── models/         # SQLAlchemy models
@@ -303,17 +303,16 @@ LIMIT 5;
 - No API key required for embeddings
 
 ### LLM Inference
-- **Cloud**: Anthropic API (e.g., `claude-sonnet-4-20250514`)
-- **Local**: Docker Model Runner with OpenAI-compatible API (e.g., `ai/qwen3-coder`, `ai/glm-4.7-flash`, `ai/devstral-small-2`)
+- Docker Model Runner with OpenAI-compatible API (e.g., `ai/qwen3-coder`, `ai/glm-4.7-flash`, `ai/devstral-small-2`)
 - Unified `llm_client.py` abstraction with automatic Redis response caching
-- Set `USE_LOCAL_LLM=true` to switch to local inference
+- All inference runs locally — no cloud API keys or costs
 
 ### RAG Pipeline
 1. User asks question or clicks "Ask about this"
 2. Query embedded using sentence-transformers
 3. Similar chunks retrieved from pgvector/Qdrant (includes embedded maintenance records)
 4. LLM cache checked for identical prior queries
-5. Context + question sent to LLM (cloud or local)
+5. Context + question sent to local LLM via Docker Model Runner
 6. Response cached and returned with source thumbnails
 
 ### MoE Experts
@@ -331,7 +330,7 @@ LIMIT 5;
 - macOS (for Homebrew setup) or manual PostgreSQL installation
 - Python 3.11+
 - Node.js 18+
-- Anthropic API key (or Docker Model Runner for local LLM)
+- Docker Desktop with Model Runner enabled
 
 ### Running Tests
 
@@ -350,10 +349,7 @@ npm test
 ## Docker Deployment
 
 ```bash
-# Cloud AI mode
-docker-compose up -d
-
-# Local LLM mode (no API key needed)
+# Start all services
 docker-compose --profile local-llm up -d
 ```
 
@@ -374,7 +370,7 @@ Services:
 
 ### v1.3.1 (2026-03-15)
 - Added Docker Model Runner support for local LLM inference (no API key needed)
-- Added LLM client abstraction layer (`llm_client.py`) supporting cloud and local backends
+- Added LLM client abstraction layer (`llm_client.py`) for local inference
 - Added Redis LLM response cache to avoid redundant inference calls
 - Added Redis Insight GUI dashboard (port 5540)
 - Added permanent Redis caching for vehicle queries and search results

--- a/architecture.svg
+++ b/architecture.svg
@@ -166,11 +166,11 @@
   <text x="970" y="267" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="bold" fill="#94A3B8">LLM Client</text>
   <text x="970" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748B">llm_client.py</text>
 
-  <!-- Claude AI Box -->
+  <!-- Cloud LLM Box -->
   <g filter="url(#glow)">
     <rect x="1050" y="150" width="130" height="120" rx="12" fill="url(#aiGrad)" class="pulse-box" style="animation-delay: 1s"/>
   </g>
-  <text x="1115" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="bold" fill="white">Claude AI</text>
+  <text x="1115" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="bold" fill="white">Cloud LLM</text>
   <text x="1115" y="198" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#FEF3C7">Anthropic API</text>
   <line x1="1065" y1="210" x2="1165" y2="210" stroke="#FEF3C7" stroke-opacity="0.3"/>
   <text x="1065" y="228" font-family="system-ui, sans-serif" font-size="10" fill="#FEF9C3">Q&amp;A Responses</text>
@@ -221,7 +221,7 @@
   <!-- Backend to LLM Client -->
   <path d="M630 270 L915 270" stroke="#6B7280" stroke-width="2" marker-end="url(#arrowhead)" class="data-flow" style="animation-delay: 0.6s"/>
 
-  <!-- LLM Client to Claude -->
+  <!-- LLM Client to Cloud LLM -->
   <path d="M1020 255 L1045 210" stroke="#6B7280" stroke-width="2" marker-end="url(#arrowhead)" class="data-flow" style="animation-delay: 0.7s"/>
 
   <!-- LLM Client to Model Runner -->

--- a/architecture.svg
+++ b/architecture.svg
@@ -166,27 +166,16 @@
   <text x="970" y="267" text-anchor="middle" font-family="system-ui, sans-serif" font-size="11" font-weight="bold" fill="#94A3B8">LLM Client</text>
   <text x="970" y="285" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748B">llm_client.py</text>
 
-  <!-- Cloud LLM Box -->
-  <g filter="url(#glow)">
-    <rect x="1050" y="150" width="130" height="120" rx="12" fill="url(#aiGrad)" class="pulse-box" style="animation-delay: 1s"/>
-  </g>
-  <text x="1115" y="180" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="bold" fill="white">Cloud LLM</text>
-  <text x="1115" y="198" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#FEF3C7">Anthropic API</text>
-  <line x1="1065" y1="210" x2="1165" y2="210" stroke="#FEF3C7" stroke-opacity="0.3"/>
-  <text x="1065" y="228" font-family="system-ui, sans-serif" font-size="10" fill="#FEF9C3">Q&amp;A Responses</text>
-  <text x="1065" y="243" font-family="system-ui, sans-serif" font-size="10" fill="#FEF9C3">RAG Context</text>
-  <text x="1065" y="258" font-family="system-ui, sans-serif" font-size="10" fill="#FEF9C3">MoE Experts</text>
-
   <!-- Docker Model Runner Box -->
   <g filter="url(#glow)">
-    <rect x="1050" y="310" width="130" height="120" rx="12" fill="url(#localLlmGrad)" class="pulse-box" style="animation-delay: 1.1s"/>
+    <rect x="1050" y="210" width="130" height="130" rx="12" fill="url(#localLlmGrad)" class="pulse-box" style="animation-delay: 1.1s"/>
   </g>
-  <text x="1115" y="340" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="bold" fill="white">Model Runner</text>
-  <text x="1115" y="358" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#CFFAFE">Local LLM</text>
-  <line x1="1065" y1="370" x2="1165" y2="370" stroke="#CFFAFE" stroke-opacity="0.3"/>
-  <text x="1065" y="388" font-family="system-ui, sans-serif" font-size="10" fill="#ECFEFF">qwen3-coder</text>
-  <text x="1065" y="403" font-family="system-ui, sans-serif" font-size="10" fill="#ECFEFF">glm-4.7-flash</text>
-  <text x="1065" y="418" font-family="system-ui, sans-serif" font-size="10" fill="#ECFEFF">devstral-small-2</text>
+  <text x="1115" y="240" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" font-weight="bold" fill="white">Model Runner</text>
+  <text x="1115" y="258" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#CFFAFE">Local LLM</text>
+  <line x1="1065" y1="270" x2="1165" y2="270" stroke="#CFFAFE" stroke-opacity="0.3"/>
+  <text x="1065" y="288" font-family="system-ui, sans-serif" font-size="10" fill="#ECFEFF">qwen3-coder</text>
+  <text x="1065" y="303" font-family="system-ui, sans-serif" font-size="10" fill="#ECFEFF">glm-4.7-flash</text>
+  <text x="1065" y="318" font-family="system-ui, sans-serif" font-size="10" fill="#ECFEFF">devstral-small-2</text>
 
   <!-- PDF Documents -->
   <g class="float-icon" style="animation-delay: 0.5s">
@@ -221,11 +210,8 @@
   <!-- Backend to LLM Client -->
   <path d="M630 270 L915 270" stroke="#6B7280" stroke-width="2" marker-end="url(#arrowhead)" class="data-flow" style="animation-delay: 0.6s"/>
 
-  <!-- LLM Client to Cloud LLM -->
-  <path d="M1020 255 L1045 210" stroke="#6B7280" stroke-width="2" marker-end="url(#arrowhead)" class="data-flow" style="animation-delay: 0.7s"/>
-
   <!-- LLM Client to Model Runner -->
-  <path d="M1020 285 L1045 355" stroke="#6B7280" stroke-width="2" marker-end="url(#arrowhead)" class="data-flow" style="animation-delay: 0.8s"/>
+  <path d="M1020 270 L1045 270" stroke="#6B7280" stroke-width="2" marker-end="url(#arrowhead)" class="data-flow" style="animation-delay: 0.7s"/>
 
   <!-- Documents to Backend -->
   <path d="M490 620 L540 555" stroke="#6B7280" stroke-width="2" marker-end="url(#arrowhead)" class="data-flow" style="animation-delay: 0.9s"/>
@@ -240,11 +226,7 @@
   <text x="655" y="455" font-family="system-ui, sans-serif" font-size="9" fill="#64748B">Cache</text>
   <text x="770" y="260" font-family="system-ui, sans-serif" font-size="9" fill="#64748B">RAG + MoE</text>
   <text x="510" y="600" font-family="system-ui, sans-serif" font-size="9" fill="#64748B">Ingest</text>
-  <text x="1030" y="195" font-family="system-ui, sans-serif" font-size="9" fill="#64748B">Cloud</text>
-  <text x="1030" y="345" font-family="system-ui, sans-serif" font-size="9" fill="#64748B">Local</text>
-
-  <!-- "or" label between Cloud/Local -->
-  <text x="1040" y="270" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" font-weight="bold" fill="#64748B">or</text>
+  <text x="1030" y="260" font-family="system-ui, sans-serif" font-size="9" fill="#64748B">Local</text>
 
   <!-- Legend -->
   <rect x="30" y="620" width="150" height="100" rx="8" fill="#1E293B" stroke="#334155"/>


### PR DESCRIPTION
## Summary
- Remove Cloud LLM box from architecture SVG diagram
- Update README tech stack, env config, AI architecture, and Docker sections to reflect local-only inference via Docker Model Runner
- Remove all Anthropic API / cloud references from documentation

## Test plan
- [ ] Verify architecture SVG renders with only Model Runner box
- [ ] Verify README accurately describes local-only LLM setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)