### PR TITLE
ci: pin checkout, setup-node, upload-artifact +4 more to commit SHA

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,10 +22,10 @@ jobs:
         working-directory: ./frontend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload npm audit results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: npm-audit-frontend-results
           path: frontend/npm-audit-results.json
@@ -57,10 +57,10 @@ jobs:
         working-directory: ./backend
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: '3.11'
 
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload pip audit results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pip-audit-backend-results
           path: backend/pip-audit-results.json
@@ -88,10 +88,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Run Trivy vulnerability scanner (filesystem)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # master
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -101,7 +101,7 @@ jobs:
           exit-code: '0'
 
       - name: Run Trivy vulnerability scanner (JSON output)
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # master
         with:
           scan-type: 'fs'
           scan-ref: '.'
@@ -126,13 +126,13 @@ jobs:
 
       - name: Upload Trivy results to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           sarif_file: 'trivy-results.sarif'
 
       - name: Upload Trivy scan results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: trivy-scan-results
           path: |
@@ -145,7 +145,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Syft
         run: |
@@ -168,7 +168,7 @@ jobs:
           syft dir:./backend -o cyclonedx-json=sbom-backend-cyclonedx.json
 
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sbom-artifacts
           path: |
@@ -191,7 +191,7 @@ jobs:
 
       - name: Upload Grype results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: grype-scan-results
           path: |
@@ -206,7 +206,7 @@ jobs:
     if: always()
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
 
       - name: Generate security summary
         run: |


### PR DESCRIPTION
## git-steer: Pin GitHub Actions to commit SHAs

Pins unpinned `uses:` references to their full commit SHA to prevent supply-chain attacks.

### Changes
**.github/workflows/security-scan.yml**
- `actions/checkout@v6` → `@de0fac2...`
- `actions/setup-node@v6` → `@48b55a0...`
- `actions/upload-artifact@v7` → `@043fb46...`
- `actions/checkout@v6` → `@de0fac2...`
- `actions/setup-python@v6` → `@a309ff8...`
- `actions/upload-artifact@v7` → `@043fb46...`
- `actions/checkout@v6` → `@de0fac2...`
- `aquasecurity/trivy-action@master` → `@ed142fd...`
- `aquasecurity/trivy-action@master` → `@ed142fd...`
- `github/codeql-action/upload-sarif@v4` → `@e46ed2c...`
- `actions/upload-artifact@v7` → `@043fb46...`
- `actions/checkout@v6` → `@de0fac2...`
- `actions/upload-artifact@v7` → `@043fb46...`
- `actions/upload-artifact@v7` → `@043fb46...`
- `actions/download-artifact@v8` → `@3e5f45b...`

> Auto-generated by git-steer freshness detector